### PR TITLE
Fix issue with null value

### DIFF
--- a/src/DateRange.php
+++ b/src/DateRange.php
@@ -115,6 +115,10 @@ class DateRange extends Field
      */
     protected function parseResponse($attribute)
     {
+        if ($attribute === null) {
+            return [null, null];
+        }
+        
         return array_pad(explode(" $this->seperator ", $attribute), 2, null);
     }
 }


### PR DESCRIPTION
If the field is null it sends null to parseResponse which would return

    [
        '',
        null
    ]

Because explode would return `['']` so it would just add an extra null value. So in your database you end up with an empty string for from and a null value for to. Which is fine because Laravel treats empty strings and null and fixes it. But if you attempt to modify the value before it goes into the database (such as an observer or static::creating or anything) it breaks on Carbon::createFromFormat as it attempts to pass a empty string as a value and Carbon doesn't deal with it, it would just error out.

I added a check which checks if $attribute is null and just returns an array with two null values.